### PR TITLE
alterar alerta para não ser link

### DIFF
--- a/src/component/errorAlert.js
+++ b/src/component/errorAlert.js
@@ -14,7 +14,7 @@ export default class ErrorAlert extends Component {
       <div>
         { this.state.display
           && <div className="alert alert-dismissible alert-secondary">
-            <a href="/#" className="alert-link">{ this.props.name }</a>
+            <b>{ this.props.name }</b>
           </div>}
       </div>
     );


### PR DESCRIPTION
Notei que os alertas de erro são links e redirecionam para a home. O que acha de remover esse link?